### PR TITLE
use Fastly-Key instead of X-Fastly-Key

### DIFF
--- a/fastly/auth.py
+++ b/fastly/auth.py
@@ -10,7 +10,7 @@ class KeyAuthenticator(object):
         self.key = key
 
     def add_auth(self, headers):
-        headers['X-Fastly-Key'] = self.key
+        headers['Fastly-Key'] = self.key
 
 class SessionAuthenticator(object):
     def __init__(self, conn, login, password):


### PR DESCRIPTION
The use of `X-Fastly-Key` is deprecated and will not be supported long term. This branch replaces any occurrences of `X-Fastly-Key` with `Fastly-Key`.