### PR TITLE
use default context instead of setting specific one

### DIFF
--- a/fastly/connection.py
+++ b/fastly/connection.py
@@ -32,7 +32,7 @@ class Connection(object):
             self.port = 443 if self.secure else 80
 
         if self.secure:
-            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS)
+            ctx = ssl.create_default_context()
             self.http_conn = http_client.HTTPSConnection(self.host, self.port,
                                                          timeout=self.timeout, context=ctx)
         else:


### PR DESCRIPTION
Fixes #34 

I found that using the default context creation tool from `ssl` actually solved my issue so I decided to open this PR. According to the official [python docs](https://docs.python.org/3/library/ssl.html#ssl.create_default_context), this is what the method does:

> Return a new SSLContext object with default settings for the given purpose. The settings are chosen by the ssl module, and usually represent a higher security level than when calling the SSLContext constructor directly.

The tests passed fine on my local branch, but I'm not 100% sure the tests are good enough. Open to suggestions re. better testing of this.