### PR TITLE
Style - Add content type of the readme in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     url="https://github.com/fastly/fastly-py",
     packages=['fastly'],
     long_description=open('README.md').read(),
+    long_description_content_type="text/markdown",
     install_requires=[
         'six',
     ],


### PR DESCRIPTION
This permit to have markdown formatting for the readme on pypi.

See : https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata
and https://packaging.python.org/specifications/core-metadata/#description-content-type-optional