### PR TITLE
Model convenience methods + bug fixes

### DIFF
--- a/fastly/fastly.py
+++ b/fastly/fastly.py
@@ -5,7 +5,10 @@ import os
 from fastly.connection import Connection
 from fastly.auth import KeyAuthenticator, SessionAuthenticator
 from fastly.errors import AuthenticationError
-from fastly.models import Service, Version, Domain, Backend, Settings, Condition, Header
+from fastly.models import (
+    Service, Version, Domain, Backend,
+    Settings, Condition, Header, VCL
+)
 
 
 class API(object):

--- a/fastly/models.py
+++ b/fastly/models.py
@@ -91,6 +91,16 @@ class Service(Model):
     COLLECTION_PATTERN = '/service'
     INSTANCE_PATTERN = COLLECTION_PATTERN + '/$id'
 
+    def details(self):
+        resp, data = self._query('GET', '/details')
+        return data
+
+    def get_active_version_number(self):
+        versions = self.attrs.get('versions')
+        if versions:
+            return list(filter(lambda x: x['active'] is True, versions))[0]['number']
+        return None
+
     def purge_key(self, key):
         self._query('POST', '/purge/%s' % key)
 

--- a/fastly/models.py
+++ b/fastly/models.py
@@ -28,6 +28,9 @@ class Model(object):
         return self.__class__.query(self.conn, self.COLLECTION_PATTERN, method, suffix, body, **self.attrs)
 
     def save(self):
+        if self._original_attrs == self.attrs:
+            return False
+
         if self._original_attrs:
             out = {}
             for k in self.attrs:
@@ -35,13 +38,13 @@ class Model(object):
                     out[k] = self.attrs[k]
             params_str = urlencode(out)
             resp, data = self._query('PUT', body=params_str)
-
         else:
             params_str = urlencode(self.attrs)
             resp, data = self._collection_query('POST', body=params_str)
 
         self._original_attrs = data
         self.attrs = data
+        return True
 
 
     @classmethod


### PR DESCRIPTION
Additions:
- Added `create` and `delete` methods to `Model` base
- Updated `Service.version` and `Version.vcl` to use new `Model.create`
- Added convenience methods to `Service` for fetching details and active version number

Bug fixes:
- Compare `attrs` and `_original_attrs` before saving.  (Without this check, calling `.save()` on an instance without changed attributes makes a `PUT` call with no data.  Then `instance.attrs` is set to the error response for an incomplete API call, e.g. `{"msg": "Missing parameter", "detail": "param is missing or the value is empty: item_value"}`)
- Added missing `VCL` import to `fastly.py`