### PR TITLE
Fix json.loads() error with Python < 3.6

### DIFF
--- a/fastly/connection.py
+++ b/fastly/connection.py
@@ -44,7 +44,7 @@ class Connection(object):
 
         self.http_conn.request(method, self.root + path, body, headers=headers)
         response = self.http_conn.getresponse()
-        body = response.read()
+        body = response.read().decode('utf-8')
         try:
             data = json.loads(body)
         except ValueError:


### PR DESCRIPTION
`json.loads()` supports an argument of type `bytes` or `bytearray` in Python 3.6+.
In older Python versions the function only accepts an argument of type `str` and the current code causes an error:
`the JSON object must be str, not 'bytes'`.

This commit fixes the issue by explicitly decoding from UTF-8 (changing the type to `str`).