### PR TITLE
Add support for "dynamic VCL snippets"

### DIFF
--- a/fastly/fastly.py
+++ b/fastly/fastly.py
@@ -8,7 +8,7 @@ from fastly.errors import AuthenticationError
 from fastly.models import (
     Service, Version, Domain, Backend,
     Settings, Condition, Header, VCL,
-    Dictionary, DictionaryItem
+    Snippet, Dictionary, DictionaryItem
 )
 
 
@@ -67,6 +67,12 @@ class API(object):
 
     def vcl(self, service_id, version, name):
         return VCL.find(self.conn, service_id=service_id, version=version, name=name)
+
+    def snippets(self, service_id, version):
+        return Snippet.list(self.conn, service_id=service_id, version=version)
+
+    def snippet(self, service_id, id):
+        return Snippet.find(self.conn, service_id=service_id, id=id)
 
     def dictionaries(self, service_id, version):
         return Dictionary.list(self.conn, service_id=service_id, version=version)

--- a/fastly/models.py
+++ b/fastly/models.py
@@ -220,6 +220,14 @@ class VCL(Model):
         resp, data = self._query('PUT', '/main')
         return data
 
+class Snippet(Model):
+    COLLECTION_PATTERN = Version.COLLECTION_PATTERN + '/$version/snippet'
+    INSTANCE_PATTERN = Service.COLLECTION_PATTERN + '/$service_id/snippet/$id'
+
+    def fetch(self):
+        resp, data = self._query('GET')
+        return data
+
 class Dictionary(Model):
     COLLECTION_PATTERN = Version.COLLECTION_PATTERN + '/$version/dictionary'
     INSTANCE_PATTERN = COLLECTION_PATTERN + '/$name'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
     version=__version__,  # pylint: disable=undefined-variable
     author="Fastly",
     author_email="support@fastly.com",
-    description="Fastly python API",
     classifiers=[
         "Operating System :: OS Independent",
         "Programming Language :: Python",


### PR DESCRIPTION
This adds support for fetching and updating "dynamic VCL snippets", see https://docs.fastly.com/vcl/vcl-snippets/using-dynamic-vcl-snippets/ for more info.

Please note that this includes https://github.com/fastly/fastly-py/pull/61 as otherwise the package won't install.