### PR TITLE
Move from native Python http package to requests package for HTTP(S), providing proxy support among other things

### DIFF
--- a/fastly/connection.py
+++ b/fastly/connection.py
@@ -1,62 +1,49 @@
 from __future__ import absolute_import
 
-import json
-import ssl
-
-from six.moves import http_client
-
 from fastly._version import __version__
 from fastly import errors
+from requests_toolbelt.sessions import BaseUrlSession
 
 
-class Connection(object):
+class Session(object):
     def __init__(self, host='api.fastly.com', secure=True, port=None, root='', timeout=10.0):
         self.host = host
         self.secure = secure
-        self.port = port
+        self.scheme = 'https://' if secure is True else 'http://'
+        self.port = port if port is not None else (443 if secure is True else 80)
         self.root = root
         self.timeout = timeout
-
+        self.url = '{scheme}{host}:{port}'.format(scheme=self.scheme, host=self.host, port=self.port)
         self.authenticator = None
-        self.http_conn = None
-        self.default_headers = { 'User-Agent': 'fastly-py-v{}'.format(__version__) }
+        # self.http_conn = None
+        self.default_headers = {'User-Agent': 'fastly-py-v{}'.format(__version__)}
+        self.session = BaseUrlSession(self.url)
+        self.session.headers.update(self.default_headers)
 
     def request(self, method, path, body=None, headers=None):
-
         if not headers:
             headers = {}
 
-        headers.update(self.default_headers)
-
-        if not self.port:
-            self.port = 443 if self.secure else 80
-
-        if self.secure:
-            ctx = ssl.create_default_context()
-            self.http_conn = http_client.HTTPSConnection(self.host, self.port,
-                                                         timeout=self.timeout, context=ctx)
-        else:
-            self.http_conn = http_client.HTTPConnection(self.host, self.port,
-                                                        timeout=self.timeout)
+        if headers is not None:
+            self.session.headers.update(headers)
 
         if self.authenticator:
-            self.authenticator.add_auth(headers)
+            self.authenticator.add_auth(self.session.headers)
 
-        self.http_conn.request(method, self.root + path, body, headers=headers)
-        response = self.http_conn.getresponse()
-        body = response.read().decode('utf-8')
+        response = self.session.request(method, path, data=body, headers=headers)
+
         try:
-            data = json.loads(body)
+            data = response.json()
         except ValueError:
-            data = body
+            data = response.content
 
-        if response.status in [401, 403]:
+        if response.status_code in [401, 403]:
             raise errors.AuthenticationError()
-        elif response.status == 500:
+        elif response.status_code == 500:
             raise errors.InternalServerError()
-        elif response.status == 400:
+        elif response.status_code == 400:
             raise errors.BadRequestError(body)
-        elif response.status == 404:
+        elif response.status_code == 404:
             raise errors.NotFoundError()
 
-        return (response, data)
+        return response, data

--- a/fastly/errors.py
+++ b/fastly/errors.py
@@ -1,14 +1,17 @@
-"""
-"""
+"""Exceptions"""
+
 
 class FastlyError(Exception):
     pass
 
+
 class AuthenticationError(FastlyError):
     pass
 
+
 class InternalServerError(FastlyError):
     pass
+
 
 class BadRequestError(FastlyError):
     def __init__(self, reason):
@@ -16,6 +19,7 @@ class BadRequestError(FastlyError):
 
     def __str__(self):
         return repr(self.reason)
+
 
 class NotFoundError(FastlyError):
     pass

--- a/fastly/fastly.py
+++ b/fastly/fastly.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import json
 import os
 
-from fastly.connection import Connection
+from fastly.connection import Session
 from fastly.auth import KeyAuthenticator
 from fastly.errors import AuthenticationError
 from fastly.models import (
@@ -14,71 +14,73 @@ from fastly.models import (
 
 
 class API(object):
-    def __init__(self, host=os.environ.get('FASTLY_HOST', 'api.fastly.com'), secure=os.environ.get('FASTLY_SECURE', 'true'), port=None, root='',
+    def __init__(self,
+                 host=os.environ.get('FASTLY_HOST', 'api.fastly.com'),
+                 secure=os.environ.get('FASTLY_SECURE', 'true'), port=None, root='',
                  timeout=5.0, key=None):
         secure = secure.lower() in ['true', '1', 't', 'y', 'yes']
 
-        self.conn = Connection(host, secure, port, root, timeout)
+        self.session = Session(host, secure, port, root, timeout)
 
         if key:
             self.authenticate_by_key(key)
 
     def authenticate_by_key(self, key):
-        self.conn.authenticator = KeyAuthenticator(key)
+        self.session.authenticator = KeyAuthenticator(key)
 
     def deauthenticate(self):
-        self.conn.authenticator = None
+        self.session.authenticator = None
 
     def services(self):
-        return Service.list(self.conn)
+        return Service.list(self.session)
 
-    def service(self, id):
-        return Service.find(self.conn, id=id)
+    def service(self, _id):
+        return Service.find(self.session, id=_id)
 
     def versions(self, service_id):
-        return Version.list(self.conn, service_id=service_id)
+        return Version.list(self.session, service_id=service_id)
 
     def version(self, service_id, version):
-        return Version.find(self.conn, service_id=service_id, number=version)
+        return Version.find(self.session, service_id=service_id, number=version)
 
     def domains(self, service_id, version):
-        return Domain.list(self.conn, service_id=service_id, version=version)
+        return Domain.list(self.session, service_id=service_id, version=version)
 
     def domain(self, service_id, version, name):
-        return Domain.find(self.conn, service_id=service_id, version=version, name=name)
+        return Domain.find(self.session, service_id=service_id, version=version, name=name)
 
     def backends(self, service_id, version):
-        return Backend.list(self.conn, service_id=service_id, version=version)
+        return Backend.list(self.session, service_id=service_id, version=version)
 
     def backend(self, service_id, version, name):
-        return Backend.find(self.conn, service_id=service_id, version=version, name=name)
+        return Backend.find(self.session, service_id=service_id, version=version, name=name)
 
     def settings(self, service_id, version):
-        return Settings.find(self.conn, service_id=service_id, version=version)
+        return Settings.find(self.session, service_id=service_id, version=version)
 
     def condition(self, service_id, version, name):
-        return Condition.find(self.conn, service_id=service_id, version=version, name=name)
+        return Condition.find(self.session, service_id=service_id, version=version, name=name)
 
     def header(self, service_id, version, name):
-        return Header.find(self.conn, service_id=service_id, version=version, name=name)
+        return Header.find(self.session, service_id=service_id, version=version, name=name)
 
     def vcls(self, service_id, version):
-        return VCL.list(self.conn, service_id=service_id, version=version)
+        return VCL.list(self.session, service_id=service_id, version=version)
 
     def vcl(self, service_id, version, name):
-        return VCL.find(self.conn, service_id=service_id, version=version, name=name)
+        return VCL.find(self.session, service_id=service_id, version=version, name=name)
 
     def dictionaries(self, service_id, version):
-        return Dictionary.list(self.conn, service_id=service_id, version=version)
+        return Dictionary.list(self.session, service_id=service_id, version=version)
 
     def dictionary(self, service_id, version, name):
-        return Dictionary.find(self.conn, service_id=service_id, version=version, name=name)
+        return Dictionary.find(self.session, service_id=service_id, version=version, name=name)
 
     def dictionary_items(self, service_id, dictionary_id):
-        return DictionaryItem.list(self.conn, service_id=service_id, dictionary_id=dictionary_id)
+        return DictionaryItem.list(self.session, service_id=service_id, dictionary_id=dictionary_id)
 
     def dictionary_item(self, service_id, dictionary_id, item_key):
-        return DictionaryItem.find(self.conn, service_id=service_id, dictionary_id=dictionary_id, item_key=item_key)
+        return DictionaryItem.find(self.session, service_id=service_id, dictionary_id=dictionary_id, item_key=item_key)
 
     def purge_url(self, host, path, soft=False):
         headers = {}
@@ -86,9 +88,9 @@ class API(object):
             headers['Fastly-Soft-Purge'] = 1
 
         purge_path = "/purge/%s%s" % (host, path)
-        resp, data = self.conn.request(
+        resp, data = self.session.request(
             'POST', purge_path, body='', headers=headers)
-        return resp.status == 200
+        return resp.status_code == 200
 
     def soft_purge_url(self, host, path):
         return self.purge_url(host, path, True)
@@ -98,28 +100,28 @@ class API(object):
         if soft:
             headers['Fastly-Soft-Purge'] = 1
 
-        resp, data = self.conn.request('POST','/service/%s/purge_all' % service, headers=headers)
-        return resp.status == 200
+        resp, data = self.session.request('POST', '/service/%s/purge_all' % service, headers=headers)
+        return resp.status_code == 200
 
     def soft_purge_service(self, service):
         return self.purge_service(service, True)
 
     def purge_key(self, service, key, soft=False):
-        if not isinstance(self.conn.authenticator, KeyAuthenticator):
+        if not isinstance(self.session.authenticator, KeyAuthenticator):
             raise AuthenticationError("This request requires an API key")
 
         headers = {}
         if soft:
             headers['Fastly-Soft-Purge'] = 1
 
-        resp, data = self.conn.request('POST', '/service/%s/purge/%s' % (service, key), headers=headers)
-        return resp.status == 200
+        resp, data = self.session.request('POST', '/service/%s/purge/%s' % (service, key), headers=headers)
+        return resp.status_code == 200
 
     def soft_purge_key(self, service, key):
         return self.purge_key(service, key, True)
 
     def batch_purge_key(self, service, keys, soft=False):
-        if not isinstance(self.conn.authenticator, KeyAuthenticator):
+        if not isinstance(self.session.authenticator, KeyAuthenticator):
             raise AuthenticationError("This request requires an API key")
 
         body = json.dumps({"surrogate_keys": keys})
@@ -128,9 +130,9 @@ class API(object):
         if soft:
             headers['Fastly-Soft-Purge'] = 1
 
-        resp, data = self.conn.request('POST', '/service/%s/purge' % (service),
-                                       body=body, headers=headers)
-        return resp.status == 200
+        resp, data = self.session.request('POST', '/service/%s/purge' % (service),
+                                          body=body, headers=headers)
+        return resp.status_code == 200
 
     def soft_batch_purge_key(self, service, keys):
         return self.batch_purge_key(service, keys, True)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setup(
     packages=['fastly'],
     install_requires=[
         'six',
+        'requests',
+        'requests_toolbelt',
     ],
     scripts=[
         "bin/purge_service",


### PR DESCRIPTION
This is a minimalist port of the underlying HTTP code in `fastly-py` (master branch) to use the ubiquitous [requests](https://docs.python-requests.org/en/master/) package in place of the native Python HTTP package

It also makes use of [requests_toolbelt](https://pypi.org/project/requests-toolbelt/) for the simple `BaseUrlSession` which makes the session cleaner and reduces the amount of code changes required

A lot more could be done without a lot of effort (e.g. making use of a retry and back-off policy, etc.) but this is enough to provide basic support for proxies without breaking backwards compatibility with Python2

With that said, I have only tested this on cPython 3.7

Please feel free to reject this if there's no interest in maintaining new code, I'm happy to have it here simply as a resource for anyone that needs it. My requirement was quickly adding proxy support as noted in #77

From what I can tell, this project is not very actively maintained and has been de-prioritized in favor of the golang CLI. A handful of the endpoints seem to be broken. I didn't attempt to make those work