### PR TITLE
Method to create an edge dictionary under version

### DIFF
--- a/fastly/models.py
+++ b/fastly/models.py
@@ -177,6 +177,16 @@ class Version(Model):
             'content': content,
         })
 
+    def dictionary(self, name):
+        """ Create a new Dictionary under this version. """
+        return Dictionary.create(self.conn, {
+            # Parent params
+            'service_id': self.attrs['service_id'],
+            'version': self.attrs['number'],
+            # New instance params
+            'name': name,
+        })
+
 class Domain(Model):
     COLLECTION_PATTERN = Version.COLLECTION_PATTERN + '/$version/domain'
     INSTANCE_PATTERN = COLLECTION_PATTERN + '/$name'


### PR DESCRIPTION
Adds a method to create an edge dict under a version object. It works via REST API, but used to be impossible via this package.

reference: POST method in https://developer.fastly.com/reference/api/dictionaries/dictionary/