### PR TITLE
CI to automatically publish to PyPI

### DIFF
--- a/.github/scripts/pack.sh
+++ b/.github/scripts/pack.sh
@@ -1,0 +1,17 @@
+# install deps
+pip install --upgrade build
+
+# tag the version
+sed -i "s/^VERSION = .*$/VERSION = \"${VERSION}\"/" setup.py
+sed -i "s/^version = .*$/version = \"${VERSION}\"/" pyproject.toml
+
+# make a package
+mkdir -p "${GITHUB_WORKSPACE}/temp"
+python -m build --outdir "${GITHUB_WORKSPACE}/temp"
+
+# save the output filename to env
+PACKAGE_FILENAME=$(cd "${GITHUB_WORKSPACE}/temp" && ls -1 -- *.tar.gz)
+echo "PACKAGE_FILENAME=${PACKAGE_FILENAME}" >> "${GITHUB_ENV}"
+
+mkdir -p "${GITHUB_WORKSPACE}/dist"
+mv "${GITHUB_WORKSPACE}/temp/${PACKAGE_FILENAME}" "${GITHUB_WORKSPACE}/dist/${PACKAGE_FILENAME}"

--- a/.github/scripts/prepare.sh
+++ b/.github/scripts/prepare.sh
@@ -1,0 +1,10 @@
+echo "Publishing ${PROJECT_NAME} to NPM"
+echo " Publishing version: ${VERSION}"
+echo " Publish tag is ${PUBLISH_TAG}"
+
+# perform publish
+if [ "${DRY_RUN}" == "1" ]; then
+  echo "(dry run)"
+else
+  python3 -m pip install --upgrade build && python3 -m build
+fi

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -1,7 +1,7 @@
 # Parse the release tag
 
 # strip leading 'release/'
-TAG="${RELEASE_TAG#release/}"
+TAG="${GITHUB_REF_NAME#release/}"
 
 # strip leading v
 TAG_VALUE="${TAG#v}"

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -1,0 +1,34 @@
+# Parse the release tag
+
+# strip leading 'release/'
+TAG="${RELEASE_TAG#release/}"
+
+# strip leading v
+TAG_VALUE="${TAG#v}"
+
+# strip trailing -dry
+VERSION="${TAG_VALUE%-dry}"
+
+# detect valid semver
+VALID_VERSION=$(npx -y semver-parser-cli@0.2.0 "${VERSION}" --field matches)
+if [ "${VALID_VERSION}" != "true" ]; then
+  exit 1
+fi
+
+# Detect dry run mode
+DRY_RUN=0
+if [ "${TAG_VALUE}" != "${VERSION}" ]; then
+    DRY_RUN=1
+fi
+
+# publish tag ('alpha', 'beta', etc.) is used to tag the release
+PUBLISH_TAG="$(npx -y semver-parser-cli@0.2.0 "${VERSION}" --field preid)"
+if [ "${PUBLISH_TAG}" == "undefined" ]; then
+  PUBLISH_TAG=latest
+fi
+
+echo "API_CLIENT_NAME=Python"
+echo "PROJECT_NAME=fastly-py"
+echo "VERSION=${VERSION}"
+echo "DRY_RUN=${DRY_RUN}"
+echo "PUBLISH_TAG=${PUBLISH_TAG}"

--- a/.github/scripts/release_body.sh
+++ b/.github/scripts/release_body.sh
@@ -1,0 +1,25 @@
+printf '%s' "## ${API_CLIENT_NAME} API client v${VERSION}"
+
+if [ "${DRY_RUN}" == "1" ]; then
+  printf '%s' " (dry run)"
+fi
+
+echo ""
+
+# add a newline
+echo ""
+
+CODE_PATH=${CODE_PATH:-./}
+G_CODE=$(jq -r .G "${CODE_PATH}/sig.json")
+D_CODE=$(jq -r .D "${CODE_PATH}/sig.json")
+
+PACKAGE_FILESIZE=$(ls -lh "${GITHUB_WORKSPACE}/dist/${PACKAGE_FILENAME}" | awk '{print $5}')B
+
+echo "Artifact"
+echo " ${PACKAGE_FILENAME} (${PACKAGE_FILESIZE})"
+echo ""
+echo "Generated on: $(date)"
+echo "G-code: ${G_CODE}, D-code: ${D_CODE}"
+if [ "${PUBLISH_TAG}" != "latest" ]; then
+  echo "Pre-release Tag: ${PUBLISH_TAG}"
+fi

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -5,7 +5,7 @@ on:
       - 'release/v?[0-9]*'
 
 env:
-  RELEASE_TAG: ${{ github.ref_name }}
+  GITHUB_REF_NAME: ${{ github.ref_name }}
 
 jobs:
   publish:

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -1,0 +1,56 @@
+name: Release CI
+on:
+  push:
+    tags:
+      - 'release/v?[0-9]*'
+
+env:
+  RELEASE_TAG: ${{ github.ref_name }}
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: main
+      - name: Set up environment variables
+        run: ./.github/scripts/publish_env.sh >> $GITHUB_ENV
+        working-directory: ./main
+        shell: bash
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Pack API client
+        run: ./.github/scripts/pack.sh
+        working-directory: ./main
+        shell: bash
+      - name: Prepare API client for publish
+        run: ./.github/scripts/prepare.sh
+        working-directory: ./main
+        shell: bash
+      - name: Publish API client
+        if: ${{ env.DRY_RUN != '1' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_PUBLISH_TOKEN }}
+          packages-dir: ./main/dist/
+      - name: Write release body file
+        run: CODE_PATH=./main ./main/.github/scripts/release_body.sh > ./dist/release_body.txt
+        shell: bash
+      - name: Create release (dry run)
+        if: ${{ env.DRY_RUN == '1' }}
+        run: cat ./dist/release_body.txt
+      - name: Create GitHub release
+        if: ${{ env.DRY_RUN != '1' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ env.VERSION }}
+          body_path: ./dist/release_body.txt
+          files: |
+            ./dist/${{ env.PACKAGE_FILENAME }}
+          draft: false
+          prerelease: ${{ env.PUBLISH_TAG != 'latest' }}


### PR DESCRIPTION
This PR adds a publish mechanism to allow this API client to publish itself to PyPI and create a release in GitHub.

The input is to create a tag in this repo and push it, with the syntax: `release/[VERSION][-dry]`.

- `VERSION` should be the version number that the package should be published under, such as `v3.0.1` or `3.0.1-alpha.0` (leading `v` is optional and ignored)
- Specify `-dry` if you want to do a "dry run" which doesn't actually publish to PyPI or create a release

This CI is intended to be used along with the client generator project, whose job it is to generate the newest API client code, tag it with said version code, and push it to this repo.

Unless running in `-dry` mode, this CI step will create a real version in NPM, and a release in GitHub. Example run using `release/v1.0.1-alpha.0` has generated the following:
 - CI run: https://github.com/fastly/fastly-py/actions/runs/3675271644
 - PyPI release: https://pypi.org/project/fastly/1.0.1a0/
   - If the version number contains a prerelease id (such as `alpha` in this case), then the build gets handled automatically by PyPI as a prerelease. To install it you'd have to specify the specific version (`pip install fastly==1.0.1a0`).
 - GitHub release: https://github.com/fastly/fastly-py/releases/tag/release%2Fv1.0.1-alpha.0
 - Artifact (package tarball): https://github.com/fastly/fastly-py/releases/download/release%2Fv1.0.1-alpha.0/fastly-1.0.1a0.tar.gz
   - Note the artifact is added to the GitHub release as a release asset

If running in `-dry` mode, no actual NPM publish or release will be made. Example run using `release/v1.0.1-alpha.0-dry`:
 - CI run: https://github.com/fastly/fastly-py/actions/runs/3675322945
   - Click through this link into the "Publish to PyPI" job, and read the output of the "Create Release (Dry Run)" step. You'll see the following output:
      ```
      ## Python API client v1.0.1-alpha.0 (dry run)
      
      Artifact
       fastly-1.0.1a0.tar.gz (589KB)
      
      Generated on: Mon Dec 12 11:29:11 UTC 2022
      G-code: 8b4af0da, D-code: 237fa474
      Pre-release Tag: alpha
      ```

This CI relies on a PyPI [access token](https://pypi.org/help/#apitoken) with publish access to the `fastly` project. This token is stored as a repository secret under the name `PYPI_PUBLISH_TOKEN`.