### PR TITLE
X-RateLimit-Remaining sometimes contains multiple values

### DIFF
--- a/fastly/api_client.py
+++ b/fastly/api_client.py
@@ -242,7 +242,8 @@ class ApiClient(object):
             return_data = None
 
         if method != "GET" and method != "HEAD":
-            self.rate_limit_remaining = int(response_data.getheader("Fastly-RateLimit-Remaining", default=DEFAULT_RATELIMIT))
+            rate_limit = str(response_data.getheader("Fastly-RateLimit-Remaining", default=str(DEFAULT_RATELIMIT)))
+            self.rate_limit_remaining = int(rate_limit.split(',')[0])
             self.rate_limit_reset = response_data.getheader("Fastly-RateLimit-Reset", default=0)
 
         if _return_http_data_only:


### PR DESCRIPTION
This was observed by our API that uses the generated fastly-py library;

```
Traceback (most recent call last):
  File "/app/manager/lib/cdn/fastly/__init__.py", line 79, in inner
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/app/manager/lib/cdn/fastly/__init__.py", line 230, in create
    with self.transactional_version(service_id, 1) as version:
  File "/usr/local/lib/python3.11/contextlib.py", line 144, in __exit__
    next(self.gen)
  File "/app/manager/lib/cdn/fastly/__init__.py", line 639, in transactional_version
    VersionApi(self.client).activate_service_version(
  File "/app/.venv/lib/python3.11/site-packages/fastly/api/version_api.py", line 722, in activate_service_version
    return self.activate_service_version_endpoint.call_with_http_info(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/fastly/api_client.py", line 872, in call_with_http_info
    return self.api_client.call_api(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/fastly/api_client.py", line 427, in call_api
    return self.__call_api(resource_path, method,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/fastly/api_client.py", line 245, in __call_api
    self.rate_limit_remaining = int(response_data.getheader("Fastly-RateLimit-Remaining", default=DEFAULT_RATELIMIT))
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '993, 999'
```

The double integer wasn't there before, so it may have been an error on Fastly's side, this however broke our code :-)