### PR TITLE
Fix Release CI: restore contents: write so GitHub releases are created

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: main
       - name: Set up environment variables
@@ -30,7 +30,7 @@ jobs:
         working-directory: ./main
         shell: bash
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Pack API client
@@ -54,7 +54,7 @@ jobs:
         run: cat ./dist/release_body.txt
       - name: Create GitHub release
         if: ${{ env.DRY_RUN != '1' }}
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: v${{ env.VERSION }}
           body_path: ./dist/release_body.txt

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -14,7 +14,11 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # `contents: write` is needed by the "Create GitHub release" step below.
+      # Declaring this block at all drops every unlisted scope to `none`, so it
+      # cannot be omitted just because `write` is the repository default.
+      contents: write
+      # Needed for PyPI trusted publishing.
       id-token: write
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

Every `Release CI` run in this repo has failed since 2026-03-25 — the last four
releases. PyPI publishing still succeeds, so packages ship correctly and the
failure is easy to miss, but the **GitHub release is never created**.

[Failing run](https://github.com/fastly/fastly-py/actions/runs/32110434966) —
job _Publish to PyPI_, step _Create GitHub release_:

```
👩‍🏭 Creating new GitHub release for tag release/v14.1.0...
⚠️ GitHub release failed with status: 403
retrying... (2 retries remaining)
...
❌ Too many retries. Aborting...
```

## Root cause

b432a4b9 ("Use trusted publishing to publish to PyPI") added a `permissions`
block to the `publish` job:

```yaml
permissions:
  contents: read      # <-- too narrow
  id-token: write     # needed for PyPI trusted publishing
```

`id-token: write` is correct and required. The problem is that declaring a
`permissions` block **at all** drops every unlisted scope, so `contents` went
from the repository default of `write` down to `read`. The final
`softprops/action-gh-release` step needs `contents: write`, so it gets a 403.
The action retries 3× and every attempt fails identically, because this is a
permissions problem rather than a transient one.

The sibling clients already do this correctly — `fastly-js` and `fastly-ruby`
both declare `contents: write` alongside `id-token: write`.

## Changes

1. `contents: read` → `contents: write` (keeping `id-token: write`), with a
   comment explaining why the scope can't be omitted.
2. Separate commit: bump the three actions off the deprecated Node 20 runtime,
   which the runner has been force-migrating to Node 24 with a warning on every
   run — `actions/checkout@v3`→`v5`, `actions/setup-python@v4`→`v6`,
   `softprops/action-gh-release@v1`→`v3`. gh-release v3.0.0 is a runtime-only
   major bump, so no inputs change. Not the cause of the failure; fixed while in
   here.

## Follow-up (not in this PR)

Four versions are on PyPI with no corresponding GitHub release — 13.1.0rc0,
13.1.0, 14.0.0, 14.1.0. Re-running the old jobs won't help; these need creating
by hand once this lands. Last successful GitHub release is `release/v13.0.0`.

Refs DEVLIB-2259

🤖 Generated with [Claude Code](https://claude.com/claude-code)